### PR TITLE
Replace deprecated "strtobool" library

### DIFF
--- a/grc/document_checker/__init__.py
+++ b/grc/document_checker/__init__.py
@@ -1,10 +1,10 @@
-from distutils.util import strtobool
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from grc.document_checker.doc_checker_data_store import DocCheckerDataStore
 from grc.document_checker.doc_checker_state import DocCheckerState, CurrentlyInAPartnershipEnum
 from grc.document_checker.forms import PreviousNamesCheck, MarriageCivilPartnershipForm, PlanToRemainInAPartnershipForm, \
     PartnerDiedForm, PreviousPartnershipEndedForm, GenderRecognitionOutsideUKForm, EmailForm
 from grc.external_services.gov_uk_notify import GovUkNotify
+from grc.utils.strtobool import strtobool
 
 documentChecker = Blueprint('documentChecker', __name__)
 

--- a/grc/utils/strtobool.py
+++ b/grc/utils/strtobool.py
@@ -1,0 +1,15 @@
+from typing import List
+
+
+def strtobool(string_value: str) -> bool:
+    lowercase_string_value = string_value.lower()
+
+    true_values: List[str] = ['y', 'yes', 't', 'true', 'on', '1']
+    false_values: List[str] = ['n', 'no', 'f', 'false', 'off', '0']
+
+    if lowercase_string_value in true_values:
+        return True
+    elif lowercase_string_value in false_values:
+        return False
+    else:
+        raise ValueError()


### PR DESCRIPTION
We're using the deprecated distutils package.
The method we're using is "strtobool".
The recommendation for this method is to re-implement the functionality ourselves
https://peps.python.org/pep-0632/#migration-advice
https://docs.python.org/3.9/distutils/apiref.html#distutils.util.strtobool