### PR TITLE
318: Prepare for Go-Live

### DIFF
--- a/.github/workflows/backup-files-to-external-s3.yml
+++ b/.github/workflows/backup-files-to-external-s3.yml
@@ -1,0 +1,33 @@
+name: Backup files daily to external-to-Gov.UK-PaaS S3 bucket
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  backup_sandbox:
+    name: Backup files (sandbox)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Start backup job on server
+        run: |
+          curl https://geo-gender-recognition-certificate-admin.london.cloudapps.digital/jobs/backup-files?token=${{ secrets.JOB_TOKEN }}
+
+  backup_staging:
+    name: Backup files (staging)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Start backup job on server
+        run: |
+          curl https://grc-staging-admin.london.cloudapps.digital/jobs/backup-files?token=${{ secrets.JOB_TOKEN }}
+
+  backup_production:
+    name: Backup files (production)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Start backup job on server
+        run: |
+          curl https://admin.apply-gender-recognition-certificate.service.gov.uk/jobs/backup-files?token=${{ secrets.JOB_TOKEN }}

--- a/.github/workflows/grc-daily-jobs.yml
+++ b/.github/workflows/grc-daily-jobs.yml
@@ -17,7 +17,3 @@ jobs:
       - name: Send notifications
         run: |
           curl https://grc-production-admin.london.cloudapps.digital/jobs/application-notifications?token=${{ secrets.JOB_TOKEN }}
-
-      - name: Backup files
-        run: |
-          curl https://grc-production-admin.london.cloudapps.digital/jobs/backup-files?token=${{ secrets.JOB_TOKEN }}

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -106,10 +106,10 @@
         <div class="govuk-phase-banner">
             <p class="govuk-phase-banner__content">
                 <strong class="govuk-tag govuk-phase-banner__content__tag">
-                    alpha
+                    beta
                 </strong>
                 <span class="govuk-phase-banner__text">
-                    This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
+                    This is a new service.
                 </span>
             </p>
         </div>

--- a/grc/templates/base.html
+++ b/grc/templates/base.html
@@ -73,7 +73,7 @@
         <div class="govuk-phase-banner">
             <p class="govuk-phase-banner__content">
                 <strong class="govuk-tag govuk-phase-banner__content__tag">
-                    alpha
+                    beta
                 </strong>
                 <span class="govuk-phase-banner__text">
                     This is a new service - your

--- a/grc/templates/document-checker/doc-checker-base.html
+++ b/grc/templates/document-checker/doc-checker-base.html
@@ -87,7 +87,7 @@
             <div class="govuk-phase-banner">
                 <p class="govuk-phase-banner__content">
                     <strong class="govuk-tag govuk-phase-banner__content__tag">
-                        alpha
+                        beta
                     </strong>
                     <span class="govuk-phase-banner__text">
                     This is a new service - your

--- a/grc/templates/upload/_upload-files-section.html
+++ b/grc/templates/upload/_upload-files-section.html
@@ -57,7 +57,7 @@
                 <img id="loading" src="{{ url_for('static', filename='assets/images/loading.gif') }}" width="41"
                      height="41" style="display: none; margin-bottom: 20px;" alt="">
                 <input id="documents" type="file" name="documents" multiple
-                       accept=".jpg,.jpeg,.bmp,.png,.tif,.tiff,.pdf,.txt"
+                       accept=".jpg,.jpeg,.bmp,.png,.tif,.tiff,.pdf"
                        class="govuk-file-upload govuk-!-margin-bottom-4 {{ 'govuk-input--error' if form.documents.errors }}">
             </div>
             <input type="submit" name="button_clicked" value="Upload file" class="govuk-button" data-module="govuk-button">

--- a/grc/upload/forms.py
+++ b/grc/upload/forms.py
@@ -18,7 +18,7 @@ class UploadForm(FlaskForm):
             StrictRequiredIf('button_clicked', 'Upload file',
                              message='Select a JPG, BMP, PNG, TIF or PDF file smaller than 10MB',
                              validators=[
-                                 MultiFileAllowed(['jpg', 'png', 'jpeg', 'tif', 'bmp', 'pdf', 'txt'],
+                                 MultiFileAllowed(['jpg', 'png', 'jpeg', 'tif', 'bmp', 'pdf'],
                                                   message='Select a JPG, BMP, PNG, TIF or PDF file smaller than 10MB'),
                                  fileSizeLimit(10),
                                  fileVirusScan


### PR DESCRIPTION
Various pre-go-live changes:
* Change phase banner from Alpha to Beta
* Remove the ability to upload .txt from file uploads
* Backup S3 files in all environments (not just prod) (so we can test it works before go-live)