### PR TITLE
3923: Increase image quality of flattened PDFs

### DIFF
--- a/grc/utils/pdf_utils.py
+++ b/grc/utils/pdf_utils.py
@@ -111,7 +111,7 @@ def flatten_form_pdf(input_fitz_pdf_document: fitz.Document) -> fitz.Document:
 
     for page in input_fitz_pdf_document:
         try:
-            pix = page.get_pixmap()
+            pix = page.get_pixmap(dpi=150)
             new_page = output_fitz_pdf_document.new_page(pno=-1)
             new_page.insert_image(rect=new_page.bound(), pixmap=pix)
         except Exception as e:


### PR DESCRIPTION
The flattened PDF forms seem a bit blurry.
I found this option to increase the quality of the flattened forms.
It makes the file size larger, but it still seems reasonably efficient.
What do you think?